### PR TITLE
Migrate logging to go-kit/log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/brandond/homeplug_exporter
 go 1.14
 
 require (
+	github.com/go-kit/log v0.2.0
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
-	github.com/prometheus/client_golang v1.0.0
-	github.com/prometheus/common v0.9.1
+	github.com/prometheus/client_golang v1.13.0
+	github.com/prometheus/common v0.37.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -88,7 +88,7 @@ func (e *Exporter) Collect (ch chan<- prometheus.Metric) {
   defer e.mutex.Unlock()
   err := e.collect(ch)
   if err != nil {
-    level.Error(logger).Log("msg", "error scraping Homeplug", "err", err)
+    level.Error(logger).Log("msg", "Error scraping Homeplug", "err", err)
   }
 }
 

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -364,7 +364,7 @@ func read_homeplug(iface *net.Interface, conn *raw.Conn, ch chan<- HomeplugFrame
       conn.SetReadDeadline(time.Now().Add(time.Second))
       n, addr, err := conn.ReadFrom(b)
       if err != nil {
-        level.Debug(logger).Log("msg", "failed to receive message", "err", err)
+        level.Debug(logger).Log("msg", "Failed to receive message", "err", err)
         break
       }
 

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -258,7 +258,7 @@ func main() {
 
   conn, err := raw.ListenPacket(iface, etherType, nil)
   if err != nil {
-    level.Error(logger).Log("msg", "failed to listen", "err", err)
+    level.Error(logger).Log("msg", "Failed to listen", "err", err)
     os.Exit(1)
   }
 

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -306,7 +306,7 @@ ChanLoop:
         var n HomeplugNetworkInfo
         err := (&n).UnmarshalBinary(h.Payload)
         if err != nil{
-          level.Error(logger).Log("msg", "failed to unmarshal network info frame", "err", err)
+          level.Error(logger).Log("msg", "Failed to unmarshal network info frame", "err", err)
         } else {
           ni = append(ni, n)
         }

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -252,7 +252,7 @@ func main() {
 
   iface, err := get_interface_or_default(*interfaceName)
   if err != nil {
-    level.Error(logger).Log("msg", "failed to get interface", "err", err)
+    level.Error(logger).Log("msg", "Failed to get interface", "err", err)
     os.Exit(1)
   }
 

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -378,7 +378,7 @@ func read_homeplug(iface *net.Interface, conn *raw.Conn, ch chan<- HomeplugFrame
       var h HomeplugFrame
       err = (&h).UnmarshalBinary(f.Payload)
       if err != nil {
-        level.Error(logger).Log("msg", "failed to unmarshal homeplug frame", "err",  err)
+        level.Error(logger).Log("msg", Failed to unmarshal homeplug frame", "err",  err)
         continue
       }
 

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -311,7 +311,7 @@ ChanLoop:
           ni = append(ni, n)
         }
       } else {
-        level.Error(logger).Log("msg", fmt.Sprintf("got unhandled mmetype: %v", h.MMEType))
+        level.Error(logger).Log("msg", fmt.Sprintf("Got unhandled mmetype: %v", h.MMEType))
       }
     case <- time.After(time.Second):
       break ChanLoop

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -371,7 +371,7 @@ func read_homeplug(iface *net.Interface, conn *raw.Conn, ch chan<- HomeplugFrame
       var f ethernet.Frame
       err = (&f).UnmarshalBinary(b[:n])
       if err != nil {
-        level.Error(logger).Log("msg", "failed to unmarshal ethernet frame", "err", err)
+        level.Error(logger).Log("msg", "Failed to unmarshal ethernet frame", "err", err)
         continue
       }
 

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -283,7 +283,7 @@ func main() {
   })
 
   if err := http.ListenAndServe(*listeningAddress, nil); err != nil {
-    level.Error(logger).Log("msg", "failed to bind HTTP server", "err", err)
+    level.Error(logger).Log("msg", "Failed to bind HTTP server", "err", err)
     os.Exit(1)
   }
 }


### PR DESCRIPTION
Since the prometheus/common package no longer provides a wrapper for logrus, and the majority of other Prometheus exporters have migrated to go-kit/log, it makes sense to do so here also.

Update both prometheus/common and prometheus/client_golang dependencies.

Signed-off-by: Daniel Swarbrick <dswarbrick@debian.org>