### PR TITLE
Cmdline parser improvements

### DIFF
--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -34,6 +34,7 @@ var (
 	nwInfoReq = [...]byte{0xA0, 0x38}
 	nwInfoCnf = [...]byte{0xA0, 0x39}
 	hpVendor  = [...]byte{0x00, 0xB0, 0x52}
+	stRole    = [...]string{"STA", "PCO", "CCO"}
 
 	listeningAddress = kingpin.Flag("telemetry.address", "Address on which to expose metrics.").Default(":9702").String()
 	metricsEndpoint  = kingpin.Flag("telemetry.endpoint", "Path under which to expose metrics.").Default("/metrics").String()
@@ -132,6 +133,7 @@ func (n *HomeplugNetworkInfo) UnmarshalBinary(b []byte) error {
 			return err
 		}
 		n.Networks = append(n.Networks, ns)
+		log.Debugf("Network found: %s", &ns)
 		o += size
 	}
 
@@ -144,6 +146,7 @@ func (n *HomeplugNetworkInfo) UnmarshalBinary(b []byte) error {
 			return err
 		}
 		n.Stations = append(n.Stations, ss)
+		log.Debugf("Station found: %s", &ss)
 		o += size
 	}
 
@@ -157,6 +160,13 @@ type HomeplugNetworkStatus struct {
 	Role       uint8
 	CCoAddress net.HardwareAddr
 	CCoTEI     uint8
+}
+
+func (s *HomeplugNetworkStatus) String() string {
+	role := stRole[s.Role]
+	return fmt.Sprintf(
+		"NID: %s, SNID: %x, TEI: %d, Role: %s, CCo: %s, CCoTEI: %d",
+		s.NetworkID, s.ShortID, s.TEI, role, s.CCoAddress, s.CCoTEI)
 }
 
 func (s *HomeplugNetworkStatus) UnmarshalBinary(b []byte) (int, error) {
@@ -178,6 +188,12 @@ type HomeplugStationStatus struct {
 	BridgedAddress net.HardwareAddr
 	TxRate         uint8
 	RxRate         uint8
+}
+
+func (s *HomeplugStationStatus) String() string {
+	return fmt.Sprintf(
+		"MAC: %s, TEI: %d, BDA: %s, RX: %d Mbit/s, TX: %d Mbit/s",
+		s.Address, s.TEI, s.BridgedAddress, s.RxRate, s.TxRate)
 }
 
 func (s *HomeplugStationStatus) UnmarshalBinary(b []byte) (int, error) {

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -38,7 +38,8 @@ var (
 	listeningAddress = kingpin.Flag("telemetry.address", "Address on which to expose metrics.").Default(":9702").String()
 	metricsEndpoint  = kingpin.Flag("telemetry.endpoint", "Path under which to expose metrics.").Default("/metrics").String()
 	interfaceName    = kingpin.Flag("interface", "Interface to search for Homeplug devices.").String()
-	destAddress      = kingpin.Flag("destaddr", "Destination MAC address for Homeplug devices.").Default("00B052000001").HexBytes()
+	destAddress      = MacAddress(kingpin.Flag("destaddr", "Destination MAC address for Homeplug devices. Accepts 'local', 'all', and 'broadcast' as aliases.").
+				Default("local").HintOptions("local", "all", "broadcast"))
 
 	logger log.Logger
 )
@@ -150,7 +151,7 @@ func (n *HomeplugNetworkInfo) UnmarshalBinary(b []byte) error {
 }
 
 type HomeplugNetworkStatus struct {
-	NetworkID  [7]byte
+	NetworkID  net.HardwareAddr
 	ShortID    uint8
 	TEI        uint8
 	Role       uint8
@@ -162,7 +163,7 @@ func (s *HomeplugNetworkStatus) UnmarshalBinary(b []byte) (int, error) {
 	if len(b) < 17 {
 		return 0, io.ErrUnexpectedEOF
 	}
-	copy(s.NetworkID[:], b[0:7])
+	s.NetworkID = b[0:7]
 	s.ShortID = b[7]
 	s.TEI = b[8]
 	s.Role = b[9]

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -133,7 +133,7 @@ func (n *HomeplugNetworkInfo) UnmarshalBinary(b []byte) error {
 			return err
 		}
 		n.Networks = append(n.Networks, ns)
-		log.Debugf("Network found: %s", &ns)
+		level.Debug(logger).Log("msg", fmt.Sprintf("Network found: %s", &ns))
 		o += size
 	}
 
@@ -146,7 +146,7 @@ func (n *HomeplugNetworkInfo) UnmarshalBinary(b []byte) error {
 			return err
 		}
 		n.Stations = append(n.Stations, ss)
-		log.Debugf("Station found: %s", &ss)
+		level.Debug(logger).Log("msg", fmt.Sprintf("Station found: %s", &ss))
 		o += size
 	}
 

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -133,7 +133,7 @@ func (n *HomeplugNetworkInfo) UnmarshalBinary(b []byte) error {
 			return err
 		}
 		n.Networks = append(n.Networks, ns)
-		level.Debug(logger).Log("msg", fmt.Sprintf("Network found: %s", &ns))
+		level.Debug(logger).Log("msg", "Network found", "network", &ns)
 		o += size
 	}
 
@@ -146,7 +146,7 @@ func (n *HomeplugNetworkInfo) UnmarshalBinary(b []byte) error {
 			return err
 		}
 		n.Stations = append(n.Stations, ss)
-		level.Debug(logger).Log("msg", fmt.Sprintf("Station found: %s", &ss))
+		level.Debug(logger).Log("msg", "Station found", "station", &ss)
 		o += size
 	}
 
@@ -283,7 +283,7 @@ func main() {
 	prometheus.MustRegister(exporter)
 	prometheus.MustRegister(version.NewCollector("homeplug_exporter"))
 
-	level.Info(logger).Log("msg", fmt.Sprintf("Collecting from MAC address %s via interface %s", destAddress.String(), iface.Name))
+	level.Info(logger).Log("msg", fmt.Sprintf("Collecting from MAC address %s via interface %s", destAddress, iface.Name))
 	level.Info(logger).Log("msg", fmt.Sprintf("Starting Server: %s", *listeningAddress))
 
 	http.Handle(*metricsEndpoint, promhttp.Handler())

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -279,13 +279,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	dest := net.HardwareAddr((*destAddress)[0:6])
-
-	exporter := NewExporter(iface, conn, dest)
+	exporter := NewExporter(iface, conn, *destAddress)
 	prometheus.MustRegister(exporter)
 	prometheus.MustRegister(version.NewCollector("homeplug_exporter"))
 
-	level.Info(logger).Log("msg", fmt.Sprintf("Collecting from MAC address %s via interface %s", dest.String(), iface.Name))
+	level.Info(logger).Log("msg", fmt.Sprintf("Collecting from MAC address %s via interface %s", destAddress.String(), iface.Name))
 	level.Info(logger).Log("msg", fmt.Sprintf("Starting Server: %s", *listeningAddress))
 
 	http.Handle(*metricsEndpoint, promhttp.Handler())

--- a/macaddress.go
+++ b/macaddress.go
@@ -1,0 +1,42 @@
+// vim:ts=2:sw=2:et:ai:sts=2
+package main
+
+import (
+	"errors"
+	"fmt"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"net"
+)
+
+type macAddressValue struct{ v *net.HardwareAddr }
+
+func newMacAddressValue(p *net.HardwareAddr) *macAddressValue {
+	return &macAddressValue{p}
+}
+
+func (f *macAddressValue) Set(s string) error {
+	if s == "broadcast" || s == "all" {
+		s = "ff:ff:ff:ff:ff:ff"
+	}
+	if s == "local" {
+		s = "00:b0:52:00:00:01"
+	}
+	v, err := net.ParseMAC(s)
+	if err == nil && len(v) != 6 {
+		return errors.New("Invalid address length")
+	}
+	if err == nil {
+		*f.v = (net.HardwareAddr)(v)
+	}
+	return err
+}
+
+func (f *macAddressValue) Get() interface{} { return (net.HardwareAddr)(*f.v) }
+
+func (f *macAddressValue) String() string { return fmt.Sprintf("%v", *f.v) }
+
+func MacAddress(s kingpin.Settings) (target *net.HardwareAddr) {
+	target = &net.HardwareAddr{}
+	s.SetValue(newMacAddressValue(target))
+	return
+}

--- a/macaddress.go
+++ b/macaddress.go
@@ -25,7 +25,7 @@ func (m *macAddressValue) Set(s string) error {
 		if err != nil {
 			return err
 		} else if len(v) != 6 {
-			return errors.New("Invalid address length")
+			return errors.New("invalid address length")
 		}
 		*m = (macAddressValue)(v)
 	}

--- a/macaddress.go
+++ b/macaddress.go
@@ -4,8 +4,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/alecthomas/kingpin.v2"
 	"net"
+
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type macAddressValue struct{ v *net.HardwareAddr }
@@ -31,9 +32,13 @@ func (f *macAddressValue) Set(s string) error {
 	return err
 }
 
-func (f *macAddressValue) Get() interface{} { return (net.HardwareAddr)(*f.v) }
+func (f *macAddressValue) Get() interface{} {
+	return (net.HardwareAddr)(*f.v)
+}
 
-func (f *macAddressValue) String() string { return fmt.Sprintf("%v", *f.v) }
+func (f *macAddressValue) String() string {
+	return fmt.Sprintf("%v", *f.v)
+}
 
 func MacAddress(s kingpin.Settings) (target *net.HardwareAddr) {
 	target = &net.HardwareAddr{}


### PR DESCRIPTION
This PR changes the way the destaddr parameter is parsed, using net.HardwareAddr, which allows for different hw address syntaxes. Plus, it adds the local, all, and broadcast aliases, like the open-plc-tools package.

A second commit also adds more verbose logging to the received HP frames.

[Migrated from brandond#4]