### PR TITLE
[BREAKING] Adjust metric labels to HPav protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,15 @@ docker run --rm --detach --name=homeplug_exporter --net=host homeplug_exporter
 ```
 # HELP homeplug_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which homeplug_exporter was built.
 # TYPE homeplug_exporter_build_info gauge
-# HELP homeplug_network_id Logical network information
-# TYPE homeplug_network_id gauge
+homeplug_exporter_build_info{branch="main",goversion="go1.22.1",revision="",version="0.4.0"} 1
+
+# HELP homeplug_network_info Logical network information
+# TYPE homeplug_network_info gauge
+homeplug_network_info{cco_addr="de:ad:be:ef:00:01",cco_tei="1",device_addr="de:ad:be:ef:00:01",nid="52:de:ad:be:ef:00:01",role="CCO",snid="6",tei="1"} 1
 # HELP homeplug_station_rx_rate_bytes Average PHY Rx data rate
 # TYPE homeplug_station_rx_rate_bytes gauge
+homeplug_station_rx_rate_bytes{device_addr="de:ad:be:ef:00:01",nid="52:de:ad:be:ef:00:01",peer_addr="de:ad:be:ef:00:02"} 1.86e+07
 # HELP homeplug_station_tx_rate_bytes Average PHY Tx data rate
 # TYPE homeplug_station_tx_rate_bytes gauge
+homeplug_station_tx_rate_bytes{device_addr="de:ad:be:ef:00:01",nid="52:de:ad:be:ef:00:01",peer_addr="de:ad:be:ef:00:02"} 1.18e+06
 ```

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -410,11 +410,11 @@ func read_homeplug(iface *net.Interface, conn *raw.Conn, ch chan<- HomeplugNetwo
 				"msg", "Network found",
 				"device_addr", hni.Address,
 				"nid", network.NetworkID,
-				"snid", fmt.Sprintf("%d", network.ShortID),
-				"tei", fmt.Sprintf("%d", network.TEI),
+				"snid", network.ShortID,
+				"tei", network.TEI,
 				"role", stRole[network.Role],
 				"cco_addr", network.CCoAddress,
-				"cco_tei", fmt.Sprintf("%d", network.CCoTEI),
+				"cco_tei", network.CCoTEI,
 			)
 		}
 		for _, station := range hni.Stations {
@@ -423,8 +423,8 @@ func read_homeplug(iface *net.Interface, conn *raw.Conn, ch chan<- HomeplugNetwo
 				"device_addr", hni.Address,
 				"peer_addr", station.Address,
 				"bda", station.BridgedAddress,
-				"tx_rate", fmt.Sprintf("%d", station.TxRate),
-				"rx_rate", fmt.Sprintf("%d", station.RxRate),
+				"tx_rate", station.TxRate,
+				"rx_rate", station.RxRate,
 			)
 		}
 

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -107,11 +107,11 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(e.network, prometheus.GaugeValue, 1,
 				info.Address.String(),
 				network.NetworkID.String(),
-				strconv.FormatInt(int64(network.ShortID), 10),
-				strconv.FormatInt(int64(network.TEI), 10),
+				strconv.FormatUint(uint64(network.ShortID), 10),
+				strconv.FormatUint(uint64(network.TEI), 10),
 				stRole[network.Role],
 				network.CCoAddress.String(),
-				strconv.FormatInt(int64(network.CCoTEI), 10))
+				strconv.FormatUint(uint64(network.CCoTEI), 10))
 		}
 
 		network0 := info.Networks[0]
@@ -403,10 +403,8 @@ func read_homeplug(iface *net.Interface, conn *raw.Conn, ch chan<- HomeplugNetwo
 			continue
 		}
 
-		var hni HomeplugNetworkInfo
-		hni.Address = f.Source
-		err = (&hni).UnmarshalBinary(h.Payload)
-		if err != nil {
+		hni := HomeplugNetworkInfo{Address: f.Source}
+		if err := (&hni).UnmarshalBinary(h.Payload); err != nil {
 			level.Error(logger).Log("msg", "Failed to unmarshal network info frame", "err", err)
 			continue
 		}


### PR DESCRIPTION
Up to now, the metric labels were not suitable to contain all the information gathered from the HPav protocol, and the exporter crashed when more than two adaptors were present in the network.

Fixes: brandond/homeplug_exporter#5