### PR TITLE
Recursively query all remote stations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ of these aliases:
     address but remote and foreign devices do not.
 
 Note that the default destination (`local`) will only find devices on the near
-side of the PLC connection. If you want to query devices on the far side of the
-connection, you need to either specify their MAC address, or use the
-`broadcast` alias.
+side of a PLC connection.
+
+Once a reply is obtained from a device, the exporter queries directly all other
+devices connected to the same HomePlug network.
 
 
 [^1]: A "local device" is any device at the near end of a PLC connection.  
@@ -88,10 +89,13 @@ homeplug_exporter_build_info{branch="main",goversion="go1.22.1",revision="",vers
 # HELP homeplug_network_info Logical network information
 # TYPE homeplug_network_info gauge
 homeplug_network_info{cco_addr="de:ad:be:ef:00:01",cco_tei="1",device_addr="de:ad:be:ef:00:01",nid="52:de:ad:be:ef:00:01",role="CCO",snid="6",tei="1"} 1
+homeplug_network_info{cco_addr="de:ad:be:ef:00:01",cco_tei="1",device_addr="de:ad:be:ef:00:02",nid="52:de:ad:be:ef:00:01",role="STA",snid="6",tei="2"} 1
 # HELP homeplug_station_rx_rate_bytes Average PHY Rx data rate
 # TYPE homeplug_station_rx_rate_bytes gauge
 homeplug_station_rx_rate_bytes{device_addr="de:ad:be:ef:00:01",nid="52:de:ad:be:ef:00:01",peer_addr="de:ad:be:ef:00:02"} 1.86e+07
+homeplug_station_rx_rate_bytes{device_addr="de:ad:be:ef:00:02",nid="52:de:ad:be:ef:00:01",peer_addr="de:ad:be:ef:00:01"} 1.18e+06
 # HELP homeplug_station_tx_rate_bytes Average PHY Tx data rate
 # TYPE homeplug_station_tx_rate_bytes gauge
 homeplug_station_tx_rate_bytes{device_addr="de:ad:be:ef:00:01",nid="52:de:ad:be:ef:00:01",peer_addr="de:ad:be:ef:00:02"} 1.18e+06
+homeplug_station_tx_rate_bytes{device_addr="de:ad:be:ef:00:02",nid="52:de:ad:be:ef:00:01",peer_addr="de:ad:be:ef:00:01"} 1.86e+07
 ```

--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ of these aliases:
 Note that the default destination (`local`) will only find devices on the near
 side of a PLC connection.
 
-Once a reply is obtained from a device, the exporter queries directly all other
+Once a reply is obtained from a device, the exporter directly queries all other
 devices connected to the same HomePlug network.
-
 
 [^1]: A "local device" is any device at the near end of a PLC connection.  
   A "remote device" is any device at the far end of a PLC connection.  

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -333,7 +333,7 @@ func get_homeplug_netinfo(iface *net.Interface, conn *raw.Conn, dest net.Hardwar
 
 	err := write_homeplug(iface, conn, dest)
 	if err != nil {
-		return nil, fmt.Errorf("write_homeplug failed: %v", err)
+		return nil, fmt.Errorf("write_homeplug failed: %w", err)
 	}
 
 ChanLoop:
@@ -348,9 +348,8 @@ ChanLoop:
 			seen[addr] = true
 			// Query each remote station directly.
 			for _, station := range n.Stations {
-				err := write_homeplug(iface, conn, station.Address)
-				if err != nil {
-					return nil, fmt.Errorf("write_homeplug failed: %v", err)
+				if err := write_homeplug(iface, conn, station.Address); err != nil {
+					return nil, fmt.Errorf("write_homeplug failed: %w", err)
 				}
 			}
 
@@ -375,7 +374,7 @@ func write_homeplug(iface *net.Interface, conn *raw.Conn, dest net.HardwareAddr)
 
 	b, err := h.MarshalBinary()
 	if err != nil {
-		return fmt.Errorf("failed to marshal homeplug frame: %v", err)
+		return fmt.Errorf("failed to marshal homeplug frame: %w", err)
 	}
 
 	f := &ethernet.Frame{
@@ -391,12 +390,12 @@ func write_homeplug(iface *net.Interface, conn *raw.Conn, dest net.HardwareAddr)
 
 	b, err = f.MarshalBinary()
 	if err != nil {
-		return fmt.Errorf("failed to marshal ethernet frame: %v", err)
+		return fmt.Errorf("failed to marshal ethernet frame: %w", err)
 	}
 
 	_, err = conn.WriteTo(b, a)
 	if err != nil {
-		return fmt.Errorf("failed to send message: %v", err)
+		return fmt.Errorf("failed to send message: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This way we can get a complete view of the network, including the transmission rates between any two devices.