### PR TITLE
Update deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,29 @@
 module github.com/nighttsarina/homeplug_exporter
 
-go 1.14
+go 1.21
+
+toolchain go1.22.1
 
 require (
-	github.com/go-kit/log v0.2.0
+	github.com/go-kit/log v0.2.1
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
-	github.com/prometheus/client_golang v1.13.0
-	github.com/prometheus/common v0.37.0
+	github.com/prometheus/client_golang v1.19.0
+	github.com/prometheus/common v0.51.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+)
+
+require (
+	github.com/alecthomas/kingpin/v2 v2.4.0 // indirect
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/prometheus/client_model v0.6.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
+	golang.org/x/net v0.22.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/mdlayher/ethernet"
@@ -21,7 +22,6 @@ import (
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/common/version"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mdlayher/ethernet"
 	"github.com/mdlayher/raw"
 	"github.com/prometheus/client_golang/prometheus"
+	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
@@ -276,7 +277,7 @@ func main() {
 
 	exporter := NewExporter(iface, conn, *destAddress)
 	prometheus.MustRegister(exporter)
-	prometheus.MustRegister(version.NewCollector("homeplug_exporter"))
+	prometheus.MustRegister(versioncollector.NewCollector("homeplug_exporter"))
 
 	level.Info(logger).Log("msg", "Collector parameters", "destaddr", destAddress, "interface", iface.Name)
 	level.Info(logger).Log("msg", "Starting HTTP server", "telemetry.address", *listeningAddress, "telemetry.endpoint", *metricsEndpoint)

--- a/macaddress.go
+++ b/macaddress.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (


### PR DESCRIPTION
* e166389 - Support prometheus/common v0.50.0
  prometheus/common dropped the version.NewCollector() function, which is now
  provided by prometheus/client_golang v1.19.0+.
* a705b02 - Use new import path for kingpin
* ba1a5b9 - Update dependencies