### PR TITLE
Add some basic tests of packet unmarshaling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,17 +5,16 @@ go 1.21
 toolchain go1.22.1
 
 require (
+	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/go-kit/log v0.2.1
+	github.com/google/go-cmp v0.6.0
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.51.1
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
 require (
-	github.com/alecthomas/kingpin/v2 v2.4.0 // indirect
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/qualcomm_test.go
+++ b/qualcomm_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestHomeplugFrame(t *testing.T) {
+	// NW_INFO.CNF response header only.
+	buf := []byte{0x00, 0x39, 0xa0, 0x00, 0xb0, 0x52}
+
+	want := HomeplugFrame{
+		Version: [1]byte{0x00},
+		MMEType: [2]byte{0xa0, 0x39},
+		Vendor:  [3]byte{0x00, 0xb0, 0x52},
+		Payload: []uint8{},
+	}
+
+	hf := HomeplugFrame{}
+	if err := hf.UnmarshalBinary(buf); err != nil {
+		t.Errorf("unmarshal error: %v", err)
+	}
+
+	if diff := cmp.Diff(want, hf); diff != "" {
+		t.Errorf("unmarshal mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestHomeplugNetworkInfo(t *testing.T) {
+	// NW_INFO.CNF response payload for one network with two stations.
+	buf := []byte{
+		0x01, 0x2f, 0x1a, 0x52, 0x87, 0x7a, 0x78, 0x05,
+		0x0c, 0x01, 0x02, 0x00, 0x0b, 0x3b, 0x5f, 0x28,
+		0x52, 0x01, 0x02, 0x00, 0x0b, 0x3b, 0x5f, 0x28,
+		0x56, 0x03, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0x12, 0x19, 0x00, 0x0b, 0x3b, 0x5f, 0x28, 0x72,
+		0x04, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0c,
+		0x10,
+	}
+
+	want := HomeplugNetworkInfo{
+		Networks: []HomeplugNetworkStatus{
+			{
+				NetworkID:  net.HardwareAddr{0x2f, 0x1a, 0x52, 0x87, 0x7a, 0x78, 0x05},
+				ShortID:    0x0c,
+				TEI:        1,
+				Role:       2,
+				CCoAddress: net.HardwareAddr{0x00, 0x0b, 0x3b, 0x5f, 0x28, 0x52},
+				CCoTEI:     1,
+			},
+		},
+		Stations: []HomeplugStationStatus{
+			{
+				Address:        net.HardwareAddr{0x00, 0x0b, 0x3b, 0x5f, 0x28, 0x56},
+				TEI:            3,
+				BridgedAddress: net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				TxRate:         18,
+				RxRate:         25,
+			},
+			{
+				Address:        net.HardwareAddr{0x00, 0x0b, 0x3b, 0x5f, 0x28, 0x72},
+				TEI:            4,
+				BridgedAddress: net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				TxRate:         12,
+				RxRate:         16,
+			},
+		},
+	}
+
+	hni := HomeplugNetworkInfo{}
+	if err := hni.UnmarshalBinary(buf); err != nil {
+		t.Errorf("unmarshal error: %v", err)
+	}
+
+	if diff := cmp.Diff(want, hni); diff != "" {
+		t.Errorf("unmarshal mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
These are really the bare minimum tests that are needed, but we have to start somewhere.

@NightTsarina I plan to do some pretty invasive refactoring of the the unmarshaling code (which will simplify it massively), so I thought it would be highly advisable to have some tests first.