### PR TITLE
Update mdlayher deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/go-kit/log v0.2.1
 	github.com/google/go-cmp v0.6.0
-	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
-	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
+	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118
+	github.com/mdlayher/raw v0.1.0
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.51.1
 	github.com/prometheus/exporter-toolkit v0.11.0
@@ -22,7 +22,10 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/josharian/native v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/mdlayher/packet v1.0.0 // indirect
+	github.com/mdlayher/socket v0.2.1 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -373,7 +373,9 @@ func read_homeplug(iface *net.Interface, conn *raw.Conn, ch chan<- HomeplugNetwo
 		conn.SetReadDeadline(time.Now().Add(time.Second))
 		n, addr, err := conn.ReadFrom(b)
 		if err != nil {
-			level.Debug(logger).Log("msg", "Failed to receive message", "err", err)
+			if !os.IsTimeout(err) {
+				level.Error(logger).Log("msg", "Failed to receive message", "err", err)
+			}
 			break
 		}
 


### PR DESCRIPTION
Update github.com/mdlayher/raw to the latest (and last) tag, as it has been archived and is no longer maintained.

Update github.com/mdlayher/ethernet to most recent git snapshot.

Gracefully handle conn.ReadFrom() timeout error, which is expected since we set a read deadline.