### PR TITLE
Migrate from mdlayher/raw to mdlayher/packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Qualcomm Atheros chipset such as QCA6410, QCA7000, and QCA7420.
 Currently it does not support other chipsets as it uses Atheros-specific
 messages to gather statistics.
 
+**Note:** Due to the use of github.com/mdlayher/packet for low-level network
+functionality, homeplug_exporter will only work on Linux systems. Attempting to
+run it on non-Linux systems will result in "packet: not implemented on [GOOS]"
+errors.
+
 # Running
 
 Command-line flags:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118
-	github.com/mdlayher/raw v0.1.0
+	github.com/mdlayher/packet v1.1.2
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.51.1
 	github.com/prometheus/exporter-toolkit v0.11.0
@@ -22,10 +22,9 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/josharian/native v1.0.0 // indirect
+	github.com/josharian/native v1.1.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
-	github.com/mdlayher/packet v1.0.0 // indirect
-	github.com/mdlayher/socket v0.2.1 // indirect
+	github.com/mdlayher/socket v0.4.1 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect


### PR DESCRIPTION
Drop dependency on the deprecated github.com/mdlayher/raw, and instead use its successor, github.com/mdlayer/packet.

Note: this change means that homeplug_exporter will only work on Linux. However, the only non-Linux platform supported by mdlayher/raw was *BSD, and that support was incomplete & unmaintained.

Refs: #15 